### PR TITLE
Relayout dots on bounds change

### DIFF
--- a/Sources/ISPageControl.swift
+++ b/Sources/ISPageControl.swift
@@ -14,7 +14,8 @@ open class ISPageControl: UIControl {
     fileprivate var dotLayers: [CALayer] = []
     fileprivate var diameter: CGFloat { return radius * 2 }
     fileprivate var centerIndex: Int { return fullScaleIndex[1] }
-    
+    fileprivate var size: CGSize = .zero
+
     open var currentPage = 0 {
         didSet {
             guard numberOfPages > currentPage else {
@@ -23,109 +24,109 @@ open class ISPageControl: UIControl {
             update()
         }
     }
-    
+
     @IBInspectable open var inactiveTintColor: UIColor = UIColor.lightGray {
         didSet {
             setNeedsLayout()
         }
     }
-    
+
     @IBInspectable open var currentPageTintColor: UIColor = #colorLiteral(red: 0, green: 0.6276981994, blue: 1, alpha: 1) {
         didSet {
             setNeedsLayout()
         }
     }
-    
+
     @IBInspectable open var radius: CGFloat = 5 {
         didSet {
             updateDotLayersLayout()
         }
     }
-    
+
     @IBInspectable open var padding: CGFloat = 8 {
         didSet {
             updateDotLayersLayout()
         }
     }
-    
+
     @IBInspectable open var minScaleValue: CGFloat = 0.4 {
         didSet {
             setNeedsLayout()
         }
     }
-    
+
     @IBInspectable open var middleScaleValue: CGFloat = 0.7 {
         didSet {
             setNeedsLayout()
         }
     }
-    
+
     @IBInspectable open var numberOfPages: Int = 0 {
         didSet {
             setupDotLayers()
             isHidden = hideForSinglePage && numberOfPages <= 1
         }
     }
-    
+
     @IBInspectable open var hideForSinglePage: Bool = true {
         didSet {
             setNeedsLayout()
         }
     }
-    
+
     @IBInspectable open var inactiveTransparency: CGFloat = 0.4 {
         didSet {
             setNeedsLayout()
         }
     }
-    
+
     @IBInspectable open var borderWidth: CGFloat = 0 {
         didSet {
             setNeedsLayout()
         }
     }
-    
+
     @IBInspectable open var borderColor: UIColor = UIColor.clear {
         didSet {
             setNeedsLayout()
         }
     }
-    
+
     required public init?(coder aDecoder: NSCoder) {
         super.init(coder: aDecoder)
     }
-    
+
     required public init(frame: CGRect, numberOfPages: Int) {
         super.init(frame: frame)
         self.numberOfPages = numberOfPages
         setupDotLayers()
     }
-    
+
     override open var intrinsicContentSize: CGSize {
         return sizeThatFits(CGSize.zero)
     }
-    
+
     override open func sizeThatFits(_ size: CGSize) -> CGSize {
         let minValue = min(7, numberOfPages)
         return CGSize(width: CGFloat(minValue) * diameter + CGFloat(minValue - 1) * padding, height: diameter)
     }
-    
+
     open override func layoutSubviews() {
         super.layoutSubviews()
-        
+
         dotLayers.forEach {
             if borderWidth > 0 {
                 $0.borderWidth = borderWidth
                 $0.borderColor = borderColor.cgColor
             }
         }
-        
+
         update()
     }
 }
 
 private extension ISPageControl {
-    
+
     func setupDotLayers() {
         dotLayers.forEach{ $0.removeFromSuperlayer() }
         dotLayers.removeAll()
@@ -135,42 +136,43 @@ private extension ISPageControl {
             layer.addSublayer(dotLayer)
             dotLayers.append(dotLayer)
         }
-        
-        updateDotLayersLayout() // 이부분은 변경이 필요할듯
+
+        size = .zero
         setNeedsLayout()
         invalidateIntrinsicContentSize()
     }
-    
+
     func updateDotLayersLayout() {
         let floatCount = CGFloat(numberOfPages)
         let x = (bounds.size.width - diameter * floatCount - padding * (floatCount - 1)) * 0.5
         let y = (bounds.size.height - diameter) * 0.5
         var frame = CGRect(x: x, y: y, width: diameter, height: diameter)
-        
+
         dotLayers.forEach {
+            $0.setAffineTransform(CGAffineTransform.identity)
             $0.cornerRadius = radius
             $0.frame = frame
             frame.origin.x += diameter + padding
         }
     }
-    
+
     func setupDotLayersPosition() {
         let centerLayer = dotLayers[centerIndex]
         centerLayer.position = CGPoint(x: frame.width / 2, y: frame.height / 2)
-        
+
         dotLayers.enumerated().filter{ $0.offset != centerIndex }.forEach {
             let index = abs($0.offset - centerIndex)
             let interval = $0.offset > centerIndex ? diameter + padding : -(diameter + padding)
             $0.element.position = CGPoint(x: centerLayer.position.x + interval * CGFloat(index), y: $0.element.position.y)
         }
     }
-    
+
     func setupDotLayersScale() {
         dotLayers.enumerated().forEach {
             guard let first = fullScaleIndex.first, let last = fullScaleIndex.last else {
                 return
             }
-            
+
             var transform = CGAffineTransform.identity
             if !fullScaleIndex.contains($0.offset) {
                 var scaleValue: CGFloat = 0
@@ -183,30 +185,35 @@ private extension ISPageControl {
                 }
                 transform = transform.scaledBy(x: scaleValue, y: scaleValue)
             }
-            
+
             $0.element.setAffineTransform(transform)
         }
     }
-    
+
     func update() {
         dotLayers.enumerated().forEach() {
             $0.element.backgroundColor = $0.offset == currentPage ? currentPageTintColor.cgColor : inactiveTintColor.withAlphaComponent(inactiveTransparency).cgColor
         }
-        
+
+        if bounds.size != size {
+            updateDotLayersLayout()
+            size = bounds.size
+        }
+
         guard numberOfPages > limit else {
             return
         }
-        
+
         changeFullScaleIndexsIfNeeded()
         setupDotLayersPosition()
         setupDotLayersScale()
     }
-    
+
     func changeFullScaleIndexsIfNeeded() {
         guard !fullScaleIndex.contains(currentPage) else {
             return
         }
-        
+
         // TODO: Refactoring
         let moreThanBefore = (fullScaleIndex.last ?? 0) < currentPage
         if moreThanBefore {


### PR DESCRIPTION
This fixes an issue with auto layout when the size of the control changes.

The method `updateDotLayersLayout` is relatively cheap, we can remove the check for bounds size.

Sorry for noise with trimming whitespaces.